### PR TITLE
Add lambdas

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
 
 	<link rel="stylesheet" href="resources/css/style.css">
 	<script src="resources/js/riple.js" defer></script>
+	<script src="resources/js/symtable.js" defer></script>
 	<script src="resources/js/calc.js" defer></script>
 	<script src="resources/js/script.js" defer></script>
 	<meta charset="UTF-8">

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
 		<button id="btn-del" class="btn riple btn-alt">⌫</button>
 	</div>
 	<div>
-		<button id="btn-null" class="btn riple btn-secondary">&nbsp;</button>
+		<button id="btn-null" class="btn riple btn-secondary">λ</button>
 		<button id="btn-sin" class="btn riple btn-secondary">sin</button>
 		<button id="btn-ln" class="btn riple btn-secondary">ln</button>
 		<button id="btn-exp" class="btn riple btn-secondary">xʸ</button>
@@ -63,7 +63,7 @@
 		<button id="btn-sub" class="btn riple btn-secondary">-</button>
 	</div>
 	<div>
-		<button id="btn-null" class="btn riple btn-secondary">&nbsp;</button>
+		<button id="btn-null" class="btn riple btn-secondary">:</button>
 		<button id="btn-null" class="btn riple btn-secondary">&nbsp;</button>
 		<button id="btn-factorial" class="btn riple btn-secondary">!</button>
 		<button id="btn-percent" class="btn riple btn-secondary">%</button>

--- a/resources/js/calc.js
+++ b/resources/js/calc.js
@@ -169,38 +169,6 @@ function evaluate(exp, symtable) {
   }
 }
 
-class Symtable {
-  constructor(from = {}) {
-    if (from instanceof Symtable) {
-      this.lookuptable = {};
-      this.parent = from;
-    } else {
-      this.lookuptable = from;
-      this.parent = null;
-    }
-  }
-
-  lookup(symbol) {
-    if (this.lookuptable[symbol]) {
-      return this.lookuptable[symbol];
-    } else if (this.parent) {
-      return this.parent.lookup(symbol);
-    } else {
-      return undefined;
-    }
-  }
-
-  set(symbol, value) {
-    if (this.lookuptable[symbol]) {
-      return this.lookuptable[symbol] = value;
-    } else if (this.parent && this.parent.lookup(symbol)) {
-      return this.parent.set(symbol, value);
-    } else {
-      return this.lookuptable[symbol] = value;
-    }
-  }
-}
-
 const global_symtable = new Symtable({
   "e": { type: "number", value: 2.71828182846 },
   "π": { type: "number", value: 3.14159265359 },

--- a/resources/js/calc.js
+++ b/resources/js/calc.js
@@ -166,6 +166,8 @@ function evaluate(exp, symtable) {
       return evaluate(exp.lexp, symtable) + evaluate(exp.rexp, symtable);
     case "sub":
       return evaluate(exp.lexp, symtable) - evaluate(exp.rexp, symtable);
+    default:
+      console.error("Error: unknown exp type '" + exp?.type + "'");
   }
 }
 

--- a/resources/js/script.js
+++ b/resources/js/script.js
@@ -475,10 +475,19 @@ function handleButtonClick(e) {
 }
 
 function handleKeyPress(e) {
-  const key = e.key;
+  let key = e.key;
   if (e.ctrlKey) return;
 
-  if (key.length == 1 && key.match(/[a-zA-Z0-9()\.:!+-]/i)) {
+  if (e.altKey) {
+    const altMap = {
+      "l": "λ",
+      "p": "π",
+    };
+
+    key = altMap[key] ?? key;
+  }
+
+  if (key.length == 1 && key.match(/[a-zA-Z0-9()\.:!+-λπ]/i)) {
     e.preventDefault();
     handleInput(key);
   }

--- a/resources/js/symtable.js
+++ b/resources/js/symtable.js
@@ -1,0 +1,31 @@
+class Symtable {
+  constructor(from = {}) {
+    if (from instanceof Symtable) {
+      this.lookuptable = {};
+      this.parent = from;
+    } else {
+      this.lookuptable = from;
+      this.parent = null;
+    }
+  }
+
+  lookup(symbol) {
+    if (this.lookuptable[symbol]) {
+      return this.lookuptable[symbol];
+    } else if (this.parent) {
+      return this.parent.lookup(symbol);
+    } else {
+      return undefined;
+    }
+  }
+
+  set(symbol, value) {
+    if (this.lookuptable[symbol]) {
+      return this.lookuptable[symbol] = value;
+    } else if (this.parent && this.parent.lookup(symbol)) {
+      return this.parent.set(symbol, value);
+    } else {
+      return this.lookuptable[symbol] = value;
+    }
+  }
+}

--- a/resources/js/symtable.js
+++ b/resources/js/symtable.js
@@ -1,12 +1,7 @@
 class Symtable {
-  constructor(from = {}) {
-    if (from instanceof Symtable) {
-      this.lookuptable = {};
-      this.parent = from;
-    } else {
-      this.lookuptable = from;
-      this.parent = null;
-    }
+  constructor(from = null, lookuptable = {}) {
+    this.lookuptable = lookuptable;
+    this.parent = from;
   }
 
   lookup(symbol) {


### PR DESCRIPTION
closes #1; closes #2;

Adds support for lambdas with one argument: `λx.x`
Adds scoping and creates a new scope for each function call.
Adds alt keyboard shortcuts for typing `λ` and `π` (alt-l and alt-p)