### PR TITLE
Implement stringifyExp

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 	<link rel="stylesheet" href="resources/css/style.css">
 	<script src="resources/js/riple.js" defer></script>
 	<script src="resources/js/symtable.js" defer></script>
+	<script src="resources/js/exp.js" defer></script>
 	<script src="resources/js/value.js" defer></script>
 	<script src="resources/js/calc.js" defer></script>
 	<script src="resources/js/script.js" defer></script>

--- a/resources/js/exp.js
+++ b/resources/js/exp.js
@@ -1,0 +1,18 @@
+function stringifyExp(exp) {
+  switch (exp?.type) {
+    case "num": return exp.value.toString();
+    case "var": return exp.symbol;
+    case "decl": return exp.lexp.symbol + ":" + stringifyExp(exp.rexp);
+    case "lambda":
+      return "λ" + exp.vars.map(val => val.symbol).join(" ") + "." + stringifyExp(exp.exp);
+    case "fac": return "!" + stringifyExp(exp.exp);
+    case "juxtra": return stringifyExp(exp.lexp) + " " + stringifyExp(exp.rexp);
+    case "null": return "null";
+    case "par": return "(" + stringifyExp(exp.exp) + ")";
+    case "exp": return stringifyExp(exp.lexp) + "^" + stringifyExp(exp.rexp);
+    case "mul": return stringifyExp(exp.lexp) + "×" + stringifyExp(exp.rexp);
+    case "div": return stringifyExp(exp.lexp) + "÷" + stringifyExp(exp.rexp);
+    case "add": return stringifyExp(exp.lexp) + "+" + stringifyExp(exp.rexp);
+    case "sub": return stringifyExp(exp.lexp) + "-" + stringifyExp(exp.rexp);
+  }
+}

--- a/resources/js/value.js
+++ b/resources/js/value.js
@@ -6,7 +6,7 @@ class Value {
 
   toString() {
     if (this.type == "lambda") {
-      return "λ" + this.value.vars.map(val => val.symbol).join(" ") + "." + "()";
+      return "λ" + this.value.vars.map(val => val.symbol).join(" ") + "." + stringifyExp(this.value.exp);
     } else {
       return this.value;
     }


### PR DESCRIPTION
Implement the `stringifyExp` function to stringify expressions.

Todo:
- [ ] Fix for function call and exponent expressions.
  - Stringifying function calls and exponents looks strange, but it has the correct semantics.