### PR TITLE
Add log2

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
 		<button id="btn-del" class="btn riple btn-alt">⌫</button>
 	</div>
 	<div>
-		<button id="btn-null" class="btn riple btn-secondary">λ</button>
+		<button id="btn-lambda" class="btn riple btn-secondary">λ</button>
 		<button id="btn-sin" class="btn riple btn-secondary">sin</button>
 		<button id="btn-ln" class="btn riple btn-secondary">ln</button>
 		<button id="btn-exp" class="btn riple btn-secondary">xʸ</button>

--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
 	<div>
 		<button id="btn-e" class="btn riple btn-secondary">e</button>
 		<button id="btn-tan" class="btn riple btn-secondary">tan</button>
-		<button id="btn-null" class="btn riple btn-secondary">&nbsp;</button>
+		<button id="btn-log2" class="btn riple btn-secondary">log₂</button>
 		<button id="btn-sqrt" class="btn riple btn-secondary">√</button>
 		<button id="btn-1" class="btn riple">1</button>
 		<button id="btn-2" class="btn riple">2</button>

--- a/resources/js/calc.js
+++ b/resources/js/calc.js
@@ -2,7 +2,7 @@ function tokenize(str) {
   const rules = [
     ["num", /^[0-9]*\.?[0-9]+/],
     ["lambda", /^λ/],
-    ["var", /^[a-zA-ZΑ-Ωα-ω]+/],
+    ["var", /^[a-zA-ZΑ-Ωα-ω]+[₀₁₂₃₄₅₆₇₈₉]*/],
     ["lpar", /^\(/],
     ["rpar", /^\)/],
     ["exp", /^\^/],
@@ -187,6 +187,7 @@ const global_symtable = new Symtable(null, {
   "tan" : new Value("func", Value.tan),
   "ln" : new Value("func", Value.ln),
   "log" : new Value("func", Value.log),
+  "log₂" : new Value("func", Value.log2),
   "log2" : new Value("func", Value.log2),
   "√" : new Value("func", Value.sqrt),
   "∛" : new Value("func", Value.cbrt),

--- a/resources/js/script.js
+++ b/resources/js/script.js
@@ -297,6 +297,7 @@ function getType(key) {
     case 'tan':
     case 'ln':
     case 'log':
+    case 'log₂':
       return "func";
     default:
       return "null";
@@ -319,6 +320,7 @@ function isFunction(str) {
     case 'tan':
     case 'ln':
     case 'log':
+    case 'log₂':
       return true;
     default:
       return false;
@@ -342,6 +344,7 @@ function handleInput(key) {
     case 'tan':
     case 'ln':
     case 'log':
+    case 'log₂':
       insert({type: getType(key), head: getHead(key), value: [], mode: inputMode()});
       if (inputMode()) {
         moveCaretForward();


### PR DESCRIPTION
closes #10 

Adds the `log₂` button to the UI.

Bugfixes:
- Give the `λ` button the id `btn-lambda` (it used to be `btn-null`)

Todo:
 - [ ] Make log2 keyboard typeable.