### PR TITLE
Add explicit units

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
 	</div>
 	<div>
 		<button id="btn-null" class="btn riple btn-secondary">:</button>
-		<button id="btn-null" class="btn riple btn-secondary">&nbsp;</button>
+		<button id="btn-deg" class="btn riple btn-secondary">°</button>
 		<button id="btn-factorial" class="btn riple btn-secondary">!</button>
 		<button id="btn-percent" class="btn riple btn-secondary">%</button>
 		<button id="btn-0" class="btn riple">0</button>

--- a/resources/js/calc.js
+++ b/resources/js/calc.js
@@ -83,9 +83,9 @@ function parse(tokens, prec=10) {
 
   const ops = {
     '1': [],
-    '2': [],
-    '3': ['fac'],
-    '4': ['exp'],
+    '2': ['fac'],
+    '3': ['exp'],
+    '4': ['juxtra'],
     '5': ['mul', 'div'],
     '6': ['add', 'sub'],
     '7': [],
@@ -111,7 +111,7 @@ function parse(tokens, prec=10) {
   // reinsert the lookahead token if it's not undefined
   if (token) tokens.unshift(token);
 
-  if (ops[prec].includes('mul')) {
+  if (ops[prec].includes('juxtra')) {
     // while there is another token and that token is not an operator (or a closing parenthesis)
     while (tokens.length > 0 && !Object.values(ops).flat().concat(['rpar']).includes(tokens[0]?.type)) {
       const rexp = parse(tokens, prec-1);

--- a/resources/js/calc.js
+++ b/resources/js/calc.js
@@ -12,6 +12,7 @@ function tokenize(str) {
     ["sub", /^\-/],
     ["var", /^\√/],
     ["var", /^\∛/],
+    ["var", /^°/],
     ["fac", /^!/],
     ["decl", /^:/],
     ["end", /^;/],
@@ -182,6 +183,7 @@ const global_symtable = new Symtable(null, {
   "e": new Value("num", 2.71828182846),
   "π": new Value("num", 3.14159265359),
   "pi": new Value("num", 3.14159265359),
+  "°": new Value("num", 1, "deg"),
   "cos" : new Value("func", Value.cos),
   "sin" : new Value("func", Value.sin),
   "tan" : new Value("func", Value.tan),
@@ -206,5 +208,5 @@ function calculate() {
     return "";
   }
 
-  return value.toString();
+  return value?.toString() ?? 'E';
 }

--- a/resources/js/calc.js
+++ b/resources/js/calc.js
@@ -122,7 +122,7 @@ function parse(tokens, prec=10) {
   return lexp;
 }
 
-function factorial(n){
+function factorial(n) {
     return (n <= 1) ? 1 : factorial(n - 1) * n;
 }
 

--- a/resources/js/value.js
+++ b/resources/js/value.js
@@ -23,7 +23,13 @@ class Value {
 
   static exp(lval, rval) {
     if (lval.type == "num" && rval.type == "num") {
-      return new Value("num", lval.value ** rval.value);
+      if (lval.unit == "unit" && rval.unit == "unit") {
+        return new Value("num", lval.value ** rval.value);
+      } else if (lval.unit != "unit" && rval.unit == "unit") {
+        return new Value("num", lval.value ** rval.value, lval.unit);
+      } else {
+        return new Value("null", null);
+      }
     }
 
     return new Value("null", null);
@@ -97,7 +103,13 @@ class Value {
 
   static cos(val) {
     if (val.type == "num") {
-      return new Value("num", Math.cos(Value.rad(val.value)));
+      if (val.unit == "unit") {
+        return new Value("num", Math.cos(Value.rad(val.value)));
+      } else if (val.unit == "deg") {
+        return new Value("num", Math.cos(val.value * Math.PI/180.0));
+      } else {
+        return new Value("null", null);
+      }
     }
 
     return new Value("null", null);
@@ -105,7 +117,13 @@ class Value {
 
   static sin(val) {
     if (val.type == "num") {
-      return new Value("num", Math.sin(Value.rad(val.value)));
+      if (val.unit == "unit") {
+        return new Value("num", Math.sin(Value.rad(val.value)));
+      } else if (val.unit == "deg") {
+        return new Value("num", Math.sin(val.value * Math.PI/180.0));
+      } else {
+        return new Value("null", null);
+      }
     }
 
     return new Value("null", null);
@@ -113,14 +131,20 @@ class Value {
 
   static tan(val) {
     if (val.type == "num") {
-      return new Value("num", Math.tan(Value.rad(val.value)));
+      if (val.unit == "unit") {
+        return new Value("num", Math.tan(Value.rad(val.value)));
+      } else if (val.unit == "deg") {
+        return new Value("num", Math.tan(val.value * Math.PI/180.0));
+      } else {
+        return new Value("null", null);
+      }
     }
 
     return new Value("null", null);
   }
 
   static ln(val) {
-    if (val.type == "num") {
+    if (val.type == "num" && val.unit == "unit") {
       return new Value("num", Math.log(val.value));
     }
 
@@ -128,7 +152,7 @@ class Value {
   }
 
   static log(val) {
-    if (val.type == "num") {
+    if (val.type == "num" && val.unit == "unit") {
       return new Value("num", Math.log10(val.value));
     }
 
@@ -136,7 +160,7 @@ class Value {
   }
 
   static log2(val) {
-    if (val.type == "num") {
+    if (val.type == "num" && val.unit == "unit") {
       return new Value("num", Math.log2(val.value));
     }
 
@@ -144,7 +168,7 @@ class Value {
   }
 
   static sqrt(val) {
-    if (val.type == "num") {
+    if (val.type == "num" && val.unit == "unit") {
       return new Value("num", Math.sqrt(val.value));
     }
 
@@ -152,7 +176,7 @@ class Value {
   }
 
   static cbrt(val) {
-    if (val.type == "num") {
+    if (val.type == "num" && val.unit == "unit") {
       return new Value("num", Math.cbrt(val.value));
     }
 

--- a/resources/js/value.js
+++ b/resources/js/value.js
@@ -1,12 +1,21 @@
 class Value {
-  constructor(type, value) {
+  constructor(type, value, unit = "unit") {
     this.type = type;
     this.value = value;
+    this.unit = unit;
   }
 
   toString() {
     if (this.type == "lambda") {
       return "λ" + this.value.vars.map(val => val.symbol).join(" ") + "." + stringifyExp(this.value.exp);
+    } else if (this.type == "num") {
+      switch (this.unit) {
+        case "unit": return this.value;
+        case "deg": return this.value + "°";
+        default:
+          console.error("Unknown unit " + this.unit);
+          return this.value;
+        }
     } else {
       return this.value;
     }
@@ -22,7 +31,15 @@ class Value {
 
   static mul(lval, rval) {
     if (lval.type == "num" && rval.type == "num") {
-      return new Value("num", lval.value * rval.value);
+      if (lval.unit == "unit" && rval.unit == "unit") {
+        return new Value("num", lval.value * rval.value);
+      } else if (lval.unit != "unit" && rval.unit == "unit") {
+        return new Value("num", lval.value * rval.value, lval.unit);
+      } else if (lval.unit == "unit" && rval.unit != "unit") {
+        return new Value("num", lval.value * rval.value, rval.unit);
+      } else {
+        return new Value("null", null);
+      }
     }
 
     return new Value("null", null);
@@ -30,7 +47,13 @@ class Value {
 
   static div(lval, rval) {
     if (lval.type == "num" && rval.type == "num") {
-      return new Value("num", lval.value / rval.value);
+      if (lval.unit == "unit" && rval.unit == "unit") {
+        return new Value("num", lval.value / rval.value);
+      } else if (lval.unit != "unit" && rval.unit == "unit") {
+        return new Value("num", lval.value / rval.value, lval.unit);
+      } else {
+        return new Value("null", null);
+      }
     }
 
     return new Value("null", null);
@@ -38,7 +61,11 @@ class Value {
 
   static add(lval, rval) {
     if (lval.type == "num" && rval.type == "num") {
-      return new Value("num", lval.value + rval.value);
+      if (lval.unit == rval.unit) {
+        return new Value("num", lval.value + rval.value, lval.unit);
+      } else {
+        return new Value("null", null);
+      }
     }
 
     return new Value("null", null);
@@ -46,7 +73,11 @@ class Value {
 
   static sub(lval, rval) {
     if (lval.type == "num" && rval.type == "num") {
-      return new Value("num", lval.value - rval.value);
+      if (lval.unit == rval.unit) {
+        return new Value("num", lval.value - rval.value, lval.unit);
+      } else {
+        return new Value("null", null);
+      }
     }
 
     return new Value("null", null);


### PR DESCRIPTION
Closes #16;

- Adds the `°` button.
- Adds the new filed `unit` to `Value`. For a given operation, only values with compatible units can be computed (a null value is returned for incompatible units); for example, only values with the same unit can be added or subtracted, and you can't divide a number by `5°` (but you can divide, e.g., `5°` by `2` = `2.5°`).
- All values have a default `unit` of "unit"; the variable `°` has the `unit` "deg", and value `1`.
  - This makes "degree literals" (e.g. `8°`) possible: under the hood, it's a `juxtra` expression between `8` and `°`, which (thanks to the unit rules when multiplying) returns `8°`.
- Trigonometry functions accept numbers with units "unit" and "deg" — other functions only accept numbers with unit "unit".