### PR TITLE
Add alt-keyboard shortcuts for degree and square/cube-root

### DIFF
--- a/resources/js/script.js
+++ b/resources/js/script.js
@@ -485,12 +485,15 @@ function handleKeyPress(e) {
     const altMap = {
       "l": "λ",
       "p": "π",
+      "o": "°",
+      "r": "√",
+      "c": "∛",
     };
 
     key = altMap[key] ?? key;
   }
 
-  if (key.length == 1 && key.match(/[a-zA-Z0-9()\.:!\+\-λπ]/i)) {
+  if (key.length == 1 && key.match(/[a-zA-Z0-9()\.:!\+\-λπ°√∛]/i)) {
     e.preventDefault();
     handleInput(key);
   }


### PR DESCRIPTION
Adds alt keyboard shortcuts for `°`, `√`, and `∛`:
```
alt-o: °
alt-r: √
alt-c: ∛
```